### PR TITLE
Fix potential memory leak by reusing reqwest::Client

### DIFF
--- a/cloudflare-authenticator/src/lib.rs
+++ b/cloudflare-authenticator/src/lib.rs
@@ -40,6 +40,7 @@ pub struct Config {
 pub struct Authenticator {
     config: Config,
     certs: Arc<Mutex<Certs>>,
+    client: reqwest::Client,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -97,6 +98,7 @@ impl Authenticator {
                 },
                 public_certs: vec![],
             })),
+            client: reqwest::Client::new(),
         };
 
         // Start the background task to update certs periodically
@@ -146,8 +148,8 @@ impl Authenticator {
     }
 
     async fn fetch_certs(&self) -> Result<(), ValidationError> {
-        let client = reqwest::Client::new();
-        let response = client
+        let response = self
+            .client
             .get(&format!("{}/cdn-cgi/access/certs", &self.config.api))
             .header(header::CONTENT_TYPE, "application/json")
             .send()

--- a/cloudflare-dynamic-config/src/lib.rs
+++ b/cloudflare-dynamic-config/src/lib.rs
@@ -20,6 +20,7 @@ pub struct Config {
 pub struct DynamicConfigManager {
     config: Config,
     apps: Arc<Mutex<Vec<App>>>, // Use Arc and Mutex for shared access
+    client: reqwest::Client,
 }
 
 #[derive(Error, Debug)]
@@ -41,6 +42,7 @@ impl DynamicConfigManager {
         let manager = Self {
             config,
             apps: Arc::new(Mutex::new(Vec::new())),
+            client: reqwest::Client::new(),
         };
 
         // Start the background task to update apps periodically
@@ -63,8 +65,8 @@ impl DynamicConfigManager {
     async fn fetch_apps(&self) -> Result<(), ConfigError> {
         let query_params = [("match", "any"), ("ui_apps", "true")];
 
-        let client = reqwest::Client::new();
-        let response = client
+        let response = self
+            .client
             .get(&format!(
                 "{}?{}",
                 self.config.api.clone(),


### PR DESCRIPTION
A new `reqwest::Client` was being created for each request in the `cloudflare-authenticator` and `cloudflare-dynamic-config` crates. `reqwest::Client` holds a connection pool internally, and creating a new one for each request can lead to resource exhaustion and memory leaks.

This change modifies both crates to create a single `reqwest::Client` when the `Authenticator` and `DynamicConfigManager` structs are instantiated and reuses it for all subsequent requests. This is the recommended way to use `reqwest::Client` and prevents the potential memory leak.