### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   docker:
     name: push docker image to hub
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: check repository


### PR DESCRIPTION
Potential fix for [https://github.com/nihaopaul/Traefik-ForwardAuth-Cloudflare-Access-Rust/security/code-scanning/1](https://github.com/nihaopaul/Traefik-ForwardAuth-Cloudflare-Access-Rust/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key to limit the GITHUB_TOKEN to only what is strictly necessary. The best way is to set `permissions: contents: read` at the job level (for `docker`), unless you know the workflow requires additional write scopes. This change involves adding the `permissions:` block just after the job definition (before `runs-on:`), in the `.github/workflows/rust.yml` file within the `docker` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
